### PR TITLE
fix: show every pooled Codex account

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Live cards fill on their own when that login is already on the machine:
 
 - **Nous Portal:** Hermes
 - **Claude:** Hermes OAuth, or Claude Code
-- **Codex:** Hermes OAuth, or the Codex CLI
+- **Codex:** every Hermes OAuth account in the credential pool, or the Codex CLI
 - **OpenRouter:** Hermes
 - **Cursor:** Cursor app or `cursor-agent`
 - **Kimi:** Kimi Code CLI, or `KIMI_CODING_API_KEY` / `KIMI_API_KEY` in Hermes env (Coding Plan)

--- a/plugin.js
+++ b/plugin.js
@@ -18,7 +18,7 @@ import { jsx, jsxs } from 'react/jsx-runtime'
 const PLUGIN_ID = 'resetwatch'
 const PLUGIN_NAME = 'Resetwatch'
 const ROUTE = '/resetwatch'
-const VERSION = '0.2.4'
+const VERSION = '0.2.5'
 const POLL_MS = 5 * 60 * 1000
 
 const host = sdk.host
@@ -368,12 +368,15 @@ function cardsFromUsageGroups(groups, skipNous) {
 function cardsFromAccountSnapshots(snapshots) {
   const cards = []
   for (const snap of snapshots || []) {
-    const provider = providerTitle(snap.provider, snap.plan)
+    const accountLabel = String(snap.account_label || '').trim()
+    const baseProvider = providerTitle(snap.provider, snap.plan)
+    const provider = accountLabel ? `${baseProvider} — ${accountLabel}` : baseProvider
+    const accountKey = accountLabel ? `:${accountLabel}` : ''
     const extra = (snap.details || []).join(' · ')
     const windows = snap.windows || []
     windows.forEach((window, index) => {
       cards.push({
-        id: `account:${snap.provider}:${index}:${window.label}`,
+        id: `account:${snap.provider}${accountKey}:${index}:${window.label}`,
         source: 'live',
         provider,
         label: window.label,
@@ -386,7 +389,7 @@ function cardsFromAccountSnapshots(snapshots) {
     })
     if (!windows.length && extra) {
       cards.push({
-        id: `account:${snap.provider}:note`,
+        id: `account:${snap.provider}${accountKey}:note`,
         source: 'live',
         provider,
         label: provider,
@@ -513,7 +516,7 @@ function go(route) {
 }
 
 async function fetchLiveCards(sessionId, opts) {
-  const cards = []
+  let cards = []
   const errors = []
   const sid = sessionId || readSessionId()
   const fresh = !!(opts && opts.fresh)
@@ -557,15 +560,31 @@ async function fetchLiveCards(sessionId, opts) {
     }
   }
 
-  const probeResult = await probeStockAccountUsage({ cliOnly: haveAccountRpc, fresh })
+  const probeResult = await probeStockAccountUsage({ cliOnly: false, fresh })
   const probed = probeResult && probeResult.snapshots
   if (probeResult && probeResult.error && !(probed && probed.length)) {
     errors.push(probeResult.error)
   }
   let haveClaudeProbe = false
   if (probed && probed.length) {
+    const labelledProviders = new Set(
+      probed
+        .filter(snap => snap && snap.provider && String(snap.account_label || '').trim())
+        .map(snap => providerKey(snap.provider))
+    )
+    if (labelledProviders.size) {
+      cards = cards.filter(card => {
+        const match = /^account:([^:]+)/.exec(String(card.id || ''))
+        return !match || !labelledProviders.has(providerKey(match[1]))
+      })
+    }
     const extra = haveAccountRpc
-      ? probed.filter(snap => snap && snap.provider && !accountProviders.has(providerKey(snap.provider)))
+      ? probed.filter(
+          snap =>
+            snap &&
+            snap.provider &&
+            (String(snap.account_label || '').trim() || !accountProviders.has(providerKey(snap.provider)))
+        )
       : probed
     for (const snap of extra) {
       const key = providerKey(snap && snap.provider)

--- a/probe.py
+++ b/probe.py
@@ -2690,11 +2690,50 @@ def _fetch_ai_gateway_account_usage() -> Optional[dict]:
 
 def _collect_hermes() -> list[dict]:
     try:
-        from agent.account_usage import fetch_account_usage
+        from agent.account_usage import _fetch_codex_account_usage, fetch_account_usage
     except Exception:
         return []
     snapshots = []
     for provider in HERMES_PROVIDERS:
+        if provider == "openai-codex":
+            try:
+                from agent.credential_pool import load_pool
+
+                entries = [entry for entry in load_pool(provider).entries() if entry.runtime_api_key]
+
+                def fetch_entry(entry):
+                    snap = _fetch_codex_account_usage(
+                        base_url=entry.runtime_base_url,
+                        api_key=entry.runtime_api_key,
+                    )
+                    return entry, snap
+
+                if entries:
+                    results: dict[int, tuple[Any, Any]] = {}
+                    with ThreadPoolExecutor(max_workers=min(len(entries), 8)) as pool:
+                        futures = {pool.submit(fetch_entry, entry): index for index, entry in enumerate(entries)}
+                        for future, index in ((future, futures[future]) for future in futures):
+                            try:
+                                results[index] = future.result(timeout=HTTP_TIMEOUT + 2)
+                            except Exception:
+                                continue
+                    for index in sorted(results):
+                        entry, snap = results[index]
+                        if not snap or not getattr(snap, "available", False):
+                            continue
+                        snapshots.append(
+                            {
+                                "provider": snap.provider,
+                                "plan": snap.plan,
+                                "account_label": entry.label,
+                                "details": list(snap.details or ()),
+                                "windows": [_hermes_window(item) for item in (snap.windows or ())],
+                            }
+                        )
+                    if snapshots:
+                        continue
+            except Exception:
+                pass
         try:
             snap = fetch_account_usage(provider)
             if not snap or not getattr(snap, "available", False):
@@ -2797,23 +2836,28 @@ def _main_inner() -> int:
             os._exit(0)
     snapshots: list[dict] = []
     have: set[str] = set()
+    covered_providers: set[str] = set()
     cli_complete = True
     # Keep gateway import/print noise off the JSON stdout contract.
     with contextlib.redirect_stdout(io.StringIO()):
         if not cli_only:
             for snap in _collect_hermes():
                 key = _provider_key(snap.get("provider"))
-                if not key or key in have:
+                account = str(snap.get("account_label") or "").strip().lower()
+                identity = f"{key}:{account}" if account else key
+                if not key or identity in have:
                     continue
                 snapshots.append(snap)
-                have.add(key)
+                have.add(identity)
+                covered_providers.add(key)
         cli_snaps, cli_complete = _collect_cli()
         for snap in cli_snaps:
             key = _provider_key(snap.get("provider"))
-            if not key or key in have:
+            if not key or key in covered_providers or key in have:
                 continue
             snapshots.append(snap)
             have.add(key)
+            covered_providers.add(key)
     if cli_complete and snapshots:
         _store_probe_result_cache(snapshots, cli_only=cli_only)
     _emit_json(snapshots, real_stdout)


### PR DESCRIPTION
## What changed
- fetch usage for every OpenAI Codex credential in the Hermes pool
- label each card with its Hermes account name
- replace the single active-account card with the complete labelled set

## Verified
- live probe returned all 4 configured Codex Pro accounts
- `node --check plugin.js`
- `python -m py_compile probe.py`
- `git diff --check`